### PR TITLE
[DALA-801] remove "authored" field from responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ __pycache__/
 .envrc
 .idea/
 .venv/
+.vscode
 
 smoketest-report.xml

--- a/sandbox/api/FHIR/R4/responses/1_exempt-vaccine.fhir.js
+++ b/sandbox/api/FHIR/R4/responses/1_exempt-vaccine.fhir.js
@@ -51,7 +51,7 @@ export default (id) => ({
                         linkId: "exemptionPeriodEnd",
                         answer: [
                             {
-                                valueDateTime: "2022-08-13T17:15:00+00:00",
+                                valueString: "null",
                             },
                         ],
                     },

--- a/sandbox/api/FHIR/R4/responses/1_exempt-vaccine.fhir.js
+++ b/sandbox/api/FHIR/R4/responses/1_exempt-vaccine.fhir.js
@@ -1,61 +1,62 @@
 export default (id) => ({
-    "resourceType": "Bundle",
-    "type": "searchset",
-    "entry": [
+    resourceType: "Bundle",
+    type: "searchset",
+    entry: [
         {
-            "fullUrl": `QuestionnaireResponse/${id}`,
-            "resource": {
-                "resourceType": "QuestionnaireResponse",
-                "id": "2fa8f1b8-caea-4f3d-9978-c0839da568b2",
-                "questionnaire": "https://fhir.nhs.uk/Questionnaire/COVIDVaccinationMedicalExemption",
-                "status": "completed",
-                "subject": {
-                    "reference": "#p1",
-                    "identifier": {
-                        "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": id
+            fullUrl: `QuestionnaireResponse/${id}`,
+            resource: {
+                resourceType: "QuestionnaireResponse",
+                id: "2fa8f1b8-caea-4f3d-9978-c0839da568b2",
+                questionnaire:
+                    "https://fhir.nhs.uk/Questionnaire/COVIDVaccinationMedicalExemption",
+                status: "completed",
+                subject: {
+                    reference: "#p1",
+                    identifier: {
+                        system: "https://fhir.nhs.uk/Id/nhs-number",
+                        value: id,
                     },
-                    "display": "John Jonah Jameson"
+                    display: "John Jonah Jameson",
                 },
-                "contained": [
+                contained: [
                     {
-                        "id": "p1",
-                        "resourceType": "Patient",
-                        "birthDate": "1960-01-01"
-                    }
+                        id: "p1",
+                        resourceType: "Patient",
+                        birthDate: "1960-01-01",
+                    },
                 ],
-                "authored": "2021-08-13T17:15:00+00:00",
-                "item": [
+                item: [
                     {
-                        "linkId": "exemptionStatus",
-                        "answer": [
+                        linkId: "exemptionStatus",
+                        answer: [
                             {
-                                "valueCoding": {
-                                    "system": "https://fhir.nhs.uk/CodeSystem/covid-vaccination-medical-exemption",
-                                    "code": "1",
-                                    "display": "Approved: Exemption from COVID vaccination"
-                                }
-                            }
-                        ]
+                                valueCoding: {
+                                    system: "https://fhir.nhs.uk/CodeSystem/covid-vaccination-medical-exemption",
+                                    code: "1",
+                                    display:
+                                        "Approved: Exemption from COVID vaccination",
+                                },
+                            },
+                        ],
                     },
                     {
-                        "linkId": "exemptionPeriodStart",
-                        "answer": [
+                        linkId: "exemptionPeriodStart",
+                        answer: [
                             {
-                                "valueDateTime": "2021-08-13T17:15:00+00:00"
-                            }
-                        ]
+                                valueDateTime: "2021-08-13T17:15:00+00:00",
+                            },
+                        ],
                     },
                     {
-                        "linkId": "exemptionPeriodEnd",
-                        "answer": [
+                        linkId: "exemptionPeriodEnd",
+                        answer: [
                             {
-                                "valueDateTime": "2022-08-13T17:15:00+00:00"
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
-    ]
+                                valueDateTime: "2022-08-13T17:15:00+00:00",
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+    ],
 });

--- a/sandbox/api/FHIR/R4/responses/2_exempt-vaccine-and-testing.fhir.js
+++ b/sandbox/api/FHIR/R4/responses/2_exempt-vaccine-and-testing.fhir.js
@@ -1,61 +1,63 @@
 export default (id) => ({
-    "resourceType": "Bundle",
-    "type": "searchset",
-    "entry": [
-        {
-            "fullUrl": `QuestionnaireResponse/${id}`,
-            "resource": {
-                "resourceType": "QuestionnaireResponse",
-                "id": "2fa8f1b8-caea-4f3d-9978-c0839da568b2",
-                "questionnaire": "https://fhir.nhs.uk/Questionnaire/COVIDVaccinationMedicalExemption",
-                "status": "completed",
-                "subject": {
-                    "reference": "#p1",
-                    "identifier": {
-                        "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": id
-                    },
-                    "display": "John Jonah Jameson"
+  resourceType: "Bundle",
+  type: "searchset",
+  entry: [
+    {
+      fullUrl: `QuestionnaireResponse/${id}`,
+      resource: {
+        resourceType: "QuestionnaireResponse",
+        id: "2fa8f1b8-caea-4f3d-9978-c0839da568b2",
+        questionnaire:
+          "https://fhir.nhs.uk/Questionnaire/COVIDVaccinationMedicalExemption",
+        status: "completed",
+        subject: {
+          reference: "#p1",
+          identifier: {
+            system: "https://fhir.nhs.uk/Id/nhs-number",
+            value: id,
+          },
+          display: "John Jonah Jameson",
+        },
+        contained: [
+          {
+            id: "p1",
+            resourceType: "Patient",
+            birthDate: "1960-01-01",
+          },
+        ],
+        item: [
+          {
+            linkId: "exemptionStatus",
+            answer: [
+              {
+                valueCoding: {
+                  system:
+                    "https://fhir.nhs.uk/CodeSystem/covid-vaccination-medical-exemption",
+                  code: "2",
+                  display:
+                    "Approved: Exemption from COVID vaccination and testing",
                 },
-                "contained": [
-                    {
-                        "id": "p1",
-                        "resourceType": "Patient",
-                        "birthDate": "1960-01-01"
-                    }
-                ],
-                "authored": "2021-08-13T17:15:00+00:00",
-                "item": [
-                    {
-                        "linkId": "exemptionStatus",
-                        "answer": [
-                            {
-                                "valueCoding": {
-                                    "system": "https://fhir.nhs.uk/CodeSystem/covid-vaccination-medical-exemption",
-                                    "code": "2",
-                                    "display": "Approved: Exemption from COVID vaccination and testing"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "linkId": "exemptionPeriodStart",
-                        "answer": [
-                            {
-                                "valueDateTime": "2021-08-13T17:15:00+00:00"
-                            }
-                        ]
-                    },
-                    {
-                        "linkId": "exemptionPeriodEnd",
-                        "answer": [
-                            {
-                                "valueDateTime": "2022-08-13T17:15:00+00:00"
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
-    ]
+              },
+            ],
+          },
+          {
+            linkId: "exemptionPeriodStart",
+            answer: [
+              {
+                valueDateTime: "2021-08-13T17:15:00+00:00",
+              },
+            ],
+          },
+          {
+            linkId: "exemptionPeriodEnd",
+            answer: [
+              {
+                valueDateTime: "2022-08-13T17:15:00+00:00",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
 });

--- a/sandbox/api/FHIR/R4/responses/3_declined-vaccine.fhir.js
+++ b/sandbox/api/FHIR/R4/responses/3_declined-vaccine.fhir.js
@@ -1,61 +1,62 @@
 export default (id) => ({
-    "resourceType": "Bundle",
-    "type": "searchset",
-    "entry": [
-        {
-            "fullUrl": `QuestionnaireResponse/${id}`,
-            "resource": {
-                "resourceType": "QuestionnaireResponse",
-                "id": "2fa8f1b8-caea-4f3d-9978-c0839da568b2",
-                "questionnaire": "https://fhir.nhs.uk/Questionnaire/COVIDVaccinationMedicalExemption",
-                "status": "completed",
-                "subject": {
-                    "reference": "#p1",
-                    "identifier": {
-                        "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": id
-                    },
-                    "display": "John Jonah Jameson"
+  resourceType: "Bundle",
+  type: "searchset",
+  entry: [
+    {
+      fullUrl: `QuestionnaireResponse/${id}`,
+      resource: {
+        resourceType: "QuestionnaireResponse",
+        id: "2fa8f1b8-caea-4f3d-9978-c0839da568b2",
+        questionnaire:
+          "https://fhir.nhs.uk/Questionnaire/COVIDVaccinationMedicalExemption",
+        status: "completed",
+        subject: {
+          reference: "#p1",
+          identifier: {
+            system: "https://fhir.nhs.uk/Id/nhs-number",
+            value: id,
+          },
+          display: "John Jonah Jameson",
+        },
+        contained: [
+          {
+            id: "p1",
+            resourceType: "Patient",
+            birthDate: "1960-01-01",
+          },
+        ],
+        item: [
+          {
+            linkId: "exemptionStatus",
+            answer: [
+              {
+                valueCoding: {
+                  system:
+                    "https://fhir.nhs.uk/CodeSystem/covid-vaccination-medical-exemption",
+                  code: "3",
+                  display: "Declined: Exemption from COVID vaccination",
                 },
-                "contained": [
-                    {
-                        "id": "p1",
-                        "resourceType": "Patient",
-                        "birthDate": "1960-01-01"
-                    }
-                ],
-                "authored": "2021-08-13T17:15:00+00:00",
-                "item": [
-                    {
-                        "linkId": "exemptionStatus",
-                        "answer": [
-                            {
-                                "valueCoding": {
-                                    "system": "https://fhir.nhs.uk/CodeSystem/covid-vaccination-medical-exemption",
-                                    "code": "3",
-                                    "display": "Declined: Exemption from COVID vaccination"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "linkId": "exemptionPeriodStart",
-                        "answer": [
-                            {
-                                "valueDateTime": "2021-08-13T17:15:00+00:00"
-                            }
-                        ]
-                    },
-                    {
-                        "linkId": "exemptionPeriodEnd",
-                        "answer": [
-                            {
-                                "valueDateTime": "2022-08-13T17:15:00+00:00"
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
-    ]
+              },
+            ],
+          },
+          {
+            linkId: "exemptionPeriodStart",
+            answer: [
+              {
+                valueDateTime: "2021-08-13T17:15:00+00:00",
+              },
+            ],
+          },
+          {
+            linkId: "exemptionPeriodEnd",
+            answer: [
+              {
+                valueDateTime: "2022-08-13T17:15:00+00:00",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
 });

--- a/sandbox/api/FHIR/R4/responses/4_declined-vaccine-and-testing.fhir.js
+++ b/sandbox/api/FHIR/R4/responses/4_declined-vaccine-and-testing.fhir.js
@@ -1,61 +1,63 @@
 export default (id) => ({
-    "resourceType": "Bundle",
-    "type": "searchset",
-    "entry": [
-        {
-            "fullUrl": `QuestionnaireResponse/${id}`,
-            "resource": {
-                "resourceType": "QuestionnaireResponse",
-                "id": "2fa8f1b8-caea-4f3d-9978-c0839da568b2",
-                "questionnaire": "https://fhir.nhs.uk/Questionnaire/COVIDVaccinationMedicalExemption",
-                "status": "completed",
-                "subject": {
-                    "reference": "#p1",
-                    "identifier": {
-                        "system": "https://fhir.nhs.uk/Id/nhs-number",
-                        "value": id
-                    },
-                    "display": "John Jonah Jameson"
+  resourceType: "Bundle",
+  type: "searchset",
+  entry: [
+    {
+      fullUrl: `QuestionnaireResponse/${id}`,
+      resource: {
+        resourceType: "QuestionnaireResponse",
+        id: "2fa8f1b8-caea-4f3d-9978-c0839da568b2",
+        questionnaire:
+          "https://fhir.nhs.uk/Questionnaire/COVIDVaccinationMedicalExemption",
+        status: "completed",
+        subject: {
+          reference: "#p1",
+          identifier: {
+            system: "https://fhir.nhs.uk/Id/nhs-number",
+            value: id,
+          },
+          display: "John Jonah Jameson",
+        },
+        contained: [
+          {
+            id: "p1",
+            resourceType: "Patient",
+            birthDate: "1960-01-01",
+          },
+        ],
+        item: [
+          {
+            linkId: "exemptionStatus",
+            answer: [
+              {
+                valueCoding: {
+                  system:
+                    "https://fhir.nhs.uk/CodeSystem/covid-vaccination-medical-exemption",
+                  code: "4",
+                  display:
+                    "Declined: Exemption from COVID vaccination and testing",
                 },
-                "contained": [
-                    {
-                        "id": "p1",
-                        "resourceType": "Patient",
-                        "birthDate": "1960-01-01"
-                    }
-                ],
-                "authored": "2021-08-13T17:15:00+00:00",
-                "item": [
-                    {
-                        "linkId": "exemptionStatus",
-                        "answer": [
-                            {
-                                "valueCoding": {
-                                    "system": "https://fhir.nhs.uk/CodeSystem/covid-vaccination-medical-exemption",
-                                    "code": "4",
-                                    "display": "Declined: Exemption from COVID vaccination and testing"
-                                }
-                            }
-                        ]
-                    },
-                    {
-                        "linkId": "exemptionPeriodStart",
-                        "answer": [
-                            {
-                                "valueDateTime": "2021-08-13T17:15:00+00:00"
-                            }
-                        ]
-                    },
-                    {
-                        "linkId": "exemptionPeriodEnd",
-                        "answer": [
-                            {
-                                "valueDateTime": "2022-08-13T17:15:00+00:00"
-                            }
-                        ]
-                    }
-                ]
-            }
-        }
-    ]
+              },
+            ],
+          },
+          {
+            linkId: "exemptionPeriodStart",
+            answer: [
+              {
+                valueDateTime: "2021-08-13T17:15:00+00:00",
+              },
+            ],
+          },
+          {
+            linkId: "exemptionPeriodEnd",
+            answer: [
+              {
+                valueDateTime: "2022-08-13T17:15:00+00:00",
+              },
+            ],
+          },
+        ],
+      },
+    },
+  ],
 });

--- a/specification/components/examples/declined-vaccine-and-testing.fhir.json
+++ b/specification/components/examples/declined-vaccine-and-testing.fhir.json
@@ -16,7 +16,6 @@
                     ],
                     "display": "Ivor Fritagelse"
                 },
-                "authored": "2021-08-13T17:15:00+00:00",
                 "item": [
                     {
                         "linkId": "exemptionStatus",

--- a/specification/components/examples/declined-vaccine.fhir.json
+++ b/specification/components/examples/declined-vaccine.fhir.json
@@ -16,7 +16,6 @@
                     ],
                     "display": "Ivor Fritagelse"
                 },
-                "authored": "2021-08-13T17:15:00+00:00",
                 "item": [
                     {
                         "linkId": "exemptionStatus",

--- a/specification/components/examples/exempt-vaccine-and-testing.fhir.json
+++ b/specification/components/examples/exempt-vaccine-and-testing.fhir.json
@@ -16,7 +16,6 @@
           ],
           "display": "Ivor Fritagelse"
         },
-        "authored": "2021-08-13T17:15:00+00:00",
         "item": [
           {
             "linkId": "exemptionStatus",

--- a/specification/components/examples/exempt-vaccine.fhir.json
+++ b/specification/components/examples/exempt-vaccine.fhir.json
@@ -16,7 +16,6 @@
           ],
           "display": "Ivor Fritagelse"
         },
-        "authored": "2021-08-13T17:15:00+00:00",
         "item": [
           {
             "linkId": "exemptionStatus",

--- a/specification/components/schemas/QuestionnaireResponse.schema.yaml
+++ b/specification/components/schemas/QuestionnaireResponse.schema.yaml
@@ -31,8 +31,6 @@ properties:
     $ref: ./QuestionnaireResponse_Subject.schema.yaml
   contained:
     $ref: ./QuestionnaireResponse_Contained.schema.yaml
-  authored:
-    type: string
   item:
     type: array
     items:

--- a/specification/examples/declined-vaccine.fhir.json
+++ b/specification/examples/declined-vaccine.fhir.json
@@ -24,7 +24,6 @@
             "birthDate": "1960-01-01"
           }
         ],
-        "authored": "2021-08-13T17:15:00+00:00",
         "item": [
           {
             "linkId": "exemptionStatus",

--- a/specification/examples/exempt-vaccine-and-testing.fhir.json
+++ b/specification/examples/exempt-vaccine-and-testing.fhir.json
@@ -24,7 +24,6 @@
             "birthDate": "1960-01-01"
           }
         ],
-        "authored": "2021-08-13T17:15:00+00:00",
         "item": [
           {
             "linkId": "exemptionStatus",


### PR DESCRIPTION
## Summary
* Routine Change: Removes `authored` field from response

Addresses [DALA-801](https://nhsd-jira.digital.nhs.uk/browse/DALA-801) (split from [DALA-777](https://nhsd-jira.digital.nhs.uk/browse/DALA-777))

Note the AC for this MR:

> So that we might be able to be FHIR compliment for the Covid medical history API, we need to remove the 'Authored' field which is not mandatory.
> 
> We need to remove that field because we do not think that there is a need for it and this is not a mandatory field in FHIR spec.

## Reviews Required
* [x] Dev
* [ ] Test
* [ ] Tech Author
* [ ] Product Owner


## Review Checklist
:information_source: This section is to be filled in by the **reviewer**.

* [ ] I have reviewed the changes in this PR and they fill all or part of the acceptance criteria of the ticket, and the code is in a mergeable state.
* [ ] If there were infrastructure, operational, or build changes, I have made sure there is sufficient evidence that the changes will work.
* [ ] I have ensured the changelog has been updated by the submitter, if necessary.
